### PR TITLE
Fix spelling mistake "Recieved" -> "Received"

### DIFF
--- a/LibTestApp/cmac_test.c
+++ b/LibTestApp/cmac_test.c
@@ -1181,13 +1181,13 @@ test_cmac(struct MB_MGR *mb_mgr,
 
                 job = IMB_SUBMIT_JOB(mb_mgr);
                 if (job != NULL) {
-                        printf("Recieved job, expected NULL\n");
+                        printf("Received job, expected NULL\n");
                         goto end;
                 }
 
                 while ((job = IMB_FLUSH_JOB(mb_mgr)) != NULL) {
                         if (job != first_job) {
-                                printf("Invalid return job recieved\n");
+                                printf("Invalid return job received\n");
                                 goto end;
                         }
                         if (!cmac_job_ok(vec, job, job->user_data, padding,


### PR DESCRIPTION
Minor spelling mistake fixes

Signed-off-by: Colin Ian King <colin.king@canonical.com>

Fix two minor spelling mistakes in printf message text

## Description

Receive/receive is incorrectly spelled, fix this in two print messages 

## Affected parts
- [x] LibTestApp

## Motivation and Context
Spelling mistakes look unprofessional, this fix resolves two mistakes.

## How Has This Been Tested?
No. It is a trivial fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
