### PR TITLE
Fix gcc 10 warning

### DIFF
--- a/include/kasumi_internal.h
+++ b/include/kasumi_internal.h
@@ -867,7 +867,7 @@ kasumi_f8_1_buffer_bit(const kasumi_key_sched_t *pCtx, const uint64_t IV,
         /* Offset into the first byte (0 - 7 bits) */
         uint32_t remainOffset = offsetInBits % 8;
         uint32_t byteLength = (cipherLengthInBits + 7) / 8;
-        SafeBuf safeOutBuf;
+        SafeBuf safeOutBuf = {0};
         SafeBuf safeInBuf;
 
         /* IV Endianity  */


### PR DESCRIPTION
gcc 10 on Fedora Rawhide reports a warning.

$ cat /etc/redhat-release
Fedora release 33 (Rawhide)

$ gcc --version | head -1
gcc (GCC) 10.0.1 20200216 (Red Hat 10.0.1-0.8)

avx/kasumi_avx.c: In function ‘kasumi_f8_1_buffer_bit_avx’:
./include/kasumi_internal.h:845:48:
    warning: ‘safeOutBuf.b64’ may be used uninitialized in this function
    [-Wmaybe-uninitialized]
  845 |                 c->b64[0] |= BSWAP64(safeOutBuf->b64 & ~swapMask);
      |                                      ~~~~~~~~~~^~~~~
In file included from sse/kasumi_sse.c:32:
sse/kasumi_sse.c: In function ‘kasumi_f8_1_buffer_bit_sse’:
./include/kasumi_internal.h:845:48:
    warning: ‘safeOutBuf.b64’ may be used uninitialized in this function
    [-Wmaybe-uninitialized]
  845 |                 c->b64[0] |= BSWAP64(safeOutBuf->b64 & ~swapMask);
      |                                      ~~~~~~~~~~^~~~~

Fix by intializing safeOutBuf.

Signed-off-by: Kevin Traynor <ktraynor@redhat.com>

<!--- Provide a general summary of your changes in the Title above -->
as per commit message
## Description
<!--- Describe your changes in detail -->
as per commit message

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Library
- [ ] LibTestApp
- [ ] LibPerfApp
- [ ] Other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
gcc 10 compilation
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
compile tested with native gcc and clang on Fedora Rawhide.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
