### PR TITLE
perf: Fix FreeBSD compilation 

### DIFF
--- a/perf/ipsec_perf.c
+++ b/perf/ipsec_perf.c
@@ -32,7 +32,12 @@
 #include <inttypes.h>
 #include <string.h>
 #include <errno.h>
+
+#if defined (__linux__) || defined (__FreeBSD__)
+#include <stdlib.h>
+#else
 #include <malloc.h> /* memalign() or _aligned_malloc()/aligned_free() */
+#endif
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
Fixed error with malloc.h header on FreeBSD  
```
In file included from ipsec_perf.c:35:
/usr/include/malloc.h:3:2: error: "<malloc.h> has been replaced by <stdlib.h>"
#error "<malloc.h> has been replaced by <stdlib.h>"
```


## Affected parts
- [ ] Library
- [ ] Test Application
- [x] Perf Application
- [ ] Other: (please specify)

