### PR TITLE
perf: fix Undefined symbol _aligned_malloc for FreeBSD

### DIFF
--- a/perf/ipsec_perf.c
+++ b/perf/ipsec_perf.c
@@ -1079,7 +1079,7 @@ static void free_mem(uint8_t **p_buffer, imb_uint128_t **p_keys)
                 *p_buffer = NULL;
         }
 
-#ifdef LINUX
+#if defined (__linux__) || defined(__FreeBSD__)
         if (keys != NULL)
                 free(keys);
 
@@ -1142,7 +1142,7 @@ static void init_mem(uint8_t **p_buffer, imb_uint128_t **p_keys)
         const size_t alignment = 64;
         uint8_t *buf = NULL;
         imb_uint128_t *keys = NULL;
-#ifdef LINUX
+#if defined (__linux__) || defined(__FreeBSD__)
 	int ret;
 #endif
 
@@ -1151,7 +1151,7 @@ static void init_mem(uint8_t **p_buffer, imb_uint128_t **p_keys)
                 exit(EXIT_FAILURE);
         }
 
-#ifdef LINUX
+#if defined (__linux__) || defined(__FreeBSD__)
         ret = posix_memalign((void **) &buf, alignment, bufs_size);
 
 	if (ret != 0) {
@@ -1166,7 +1166,7 @@ static void init_mem(uint8_t **p_buffer, imb_uint128_t **p_keys)
                 exit(EXIT_FAILURE);
         }
 
-#ifdef LINUX
+#if defined (__linux__) || defined(__FreeBSD__)
         ret = posix_memalign((void **) &keys, alignment, keys_size);
 	if (ret != 0) {
                 fprintf(stderr, "Could not allocate memory for keys!\n");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This patch is fix for Undefined symbol "_aligned_malloc" for FreeBSD. FreeBSD uses posix_memalign from stdlib.h .

I compiled with `gmake SHARED=n
`
## Description
<!--- Describe your changes in detail -->

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Library
- [ ] Test Application
- [x] Perf Application
- [ ] Other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
