### PR TITLE
build: do not strip static libraries.

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -625,11 +625,16 @@ endif
 install: $(LIB_DIR)/$(LIBNAME)
 	install -d $(HDR_DIR)
 	install -m 0644 $(IMB_HDR) $(HDR_DIR)
-	install -d $(LIB_INSTALL_DIR)
-	install -s -m $(LIBPERM) $(LIB_DIR)/$(LIBNAME) $(LIB_INSTALL_DIR)
 	install -d $(MAN_DIR)
 	install -m 0444 $(MAN1) $(MAN_DIR)
 	install -m 0444 $(MAN2) $(MAN_DIR)
+	install -d $(LIB_INSTALL_DIR)
+ifeq ($(SHARED),y)
+	install -s -m $(LIBPERM) $(LIB_DIR)/$(LIBNAME) $(LIB_INSTALL_DIR)
+else
+	# must not strip symbol table for static libs
+	install -m $(LIBPERM) $(LIB_DIR)/$(LIBNAME) $(LIB_INSTALL_DIR)
+endif
 ifeq ($(SHARED),y)
 	cd $(LIB_INSTALL_DIR); \
 		ln -f -s $(LIB).so.$(VERSION) $(LIB).so.$(SO_VERSION); \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When installing `libIPSec_MB.a` static binary, do not strip the symbol table.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Library
- [ ] Test Application
- [ ] Perf Application
- [ ] Other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

If the symbol header is missing from the archive, the linker complains.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

`nm libIPSec_MB.a` reports only empty object files after `make install` before this patch. Afterwards it reports the full symbol table.

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
