### PR TITLE
Fix the clobbering of an XMM register on Windows in sha256_one_block_avx

### DIFF
--- a/lib/avx/sha256_one_block_avx.asm
+++ b/lib/avx/sha256_one_block_avx.asm
@@ -131,7 +131,7 @@ section .text
 
 struc STACK
 %ifndef LINUX
-_XMM_SAVE:	reso	7
+_XMM_SAVE:	reso	8
 %endif
 _XFER:		reso	1
 endstruc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The size of _XMM_SAVE was incorrectly set to 7. This PR changes it to 8.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Library
- [ ] Test Application
- [ ] Perf Application
- [ ] Other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
On Windows, the stack space for the last (%RSP+0x70) gets clobbered and when the clobbered data gets restored to XMM register, it also gets garbage data.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
An internal test app which was failing now passes.
<!--- Include details of your testing environment, tests ran to see how -->
Windows using MinGW/gcc
<!--- your change affects other areas of the code, etc. -->
It should not.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
