### PR TITLE
Always generate PDBs, even in release builds.

### DIFF
--- a/lib/win_x64.mak
+++ b/lib/win_x64.mak
@@ -12,7 +12,7 @@
 #     * Neither the name of Intel Corporation nor the names of its contributors
 #       may be used to endorse or promote products derived from this software
 #       without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -71,14 +71,14 @@ LIB_DIR = .\
 
 !ifdef DEBUG
 OPT = $(DEBUG_OPT)
-DCFLAGS = /DDEBUG /Z7
+DCFLAGS = /DDEBUG
 DAFLAGS = -gcv8
-DLFLAGS = /DEBUG
+DLFLAGS =
 !else
 OPT = /O2 /Oi
 DCFLAGS =
 DAFLAGS =
-DLFLAGS = /RELEASE
+DLFLAGS = /RELEASE /OPT:REF /OPT:ICF
 !endif
 
 !if "$(SAFE_DATA)" != "n"
@@ -98,7 +98,7 @@ DAFLAGS = $(DAFLAGS) -DSAFE_LOOKUP
 
 CC = cl
 CFLAGS_ALL = $(EXTRA_CFLAGS) /DNO_COMPAT_IMB_API_053 /I. /Iinclude /Ino-aesni \
-	/nologo /Y- /W3 /WX- /Gm- /fp:precise /EHsc
+	/nologo /Y- /W3 /WX- /Gm- /fp:precise /EHsc /Z7
 
 CFLAGS = $(CFLAGS_ALL) $(OPT) $(DCFLAGS)
 CFLAGS_NO_SIMD = $(CFLAGS_ALL) /Od $(DCFLAGS)
@@ -107,7 +107,7 @@ LIB_TOOL = lib
 LIBFLAGS = /nologo /machine:X64 /nodefaultlib
 
 LINK_TOOL = link
-LINKFLAGS = $(DLFLAGS) /nologo /machine:X64
+LINKFLAGS = $(DLFLAGS) /nologo /machine:X64 /DEBUG /INCREMENTAL:NO
 
 AS = nasm
 AFLAGS = $(DAFLAGS) -Werror -fwin64 -Xvc -DWIN_ABI -Iinclude/ \


### PR DESCRIPTION
## Description / Motivation and Context

PDBs are necessary for postmortem debugging and for teams to get reports
from Watson, so they should be built for released software too. This
change always passes /DEBUG to the MSVC linker. That switch controls
whether a PDB is generated (as in "generate debugging information") not
a statement that the resulting files are the debug specific version of
your library.

/DEBUG changes the default values of /INCREMENTAL (to on) and /OPT:REF
and /OPT:ICF to off, so those are changed back to incremental off and
linker optimizations on in debug builds.

(This missing PDB issue was discovered in fixing intel-ipsec's port in
vcpkg to build on Windows)

## Affected parts
- [x] Library
- [ ] Test Application
- [ ] Perf Application
- [ ] Other: (please specify)

## How Has This Been Tested?
This patch will be being applied by [Microsoft/vcpkg](https://github.com/microsoft/vcpkg) to the `intel-ipsec` port in order to make that port build successfully on Windows. (Previously there was no attempt to support Windows in that port)

(That's not landed yet but I tested and it now generates all the correct files:
<img width="182" alt="image" src="https://user-images.githubusercontent.com/1544943/147798996-99489a99-5769-431f-9282-e3c42780c9b7.png">
)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
