### PR TITLE
mkdep.bat: fix spelling mistake "dependecies" -> "dependencies"

### DIFF
--- a/mkdep.bat
+++ b/mkdep.bat
@@ -29,7 +29,7 @@ REM // Script to produce C/C++ dependencies based using CL compiler
 REM // 
 REM // Using: deps.bat arg1 arg2 arg3
 REM // 
-REM // arg1 - C/C++ file name to produce dependecies for
+REM // arg1 - C/C++ file name to produce dependencies for
 REM // arg2 - object file corresponding to the C/C++ file name
 REM // arg3 - include switches for the compiler
 REM // 


### PR DESCRIPTION
There is a spelling mistake in a REM remark comment. Fix it.

Signed-off-by: Colin Ian King <colin.i.king@gmail.com>

## Description
Fix minor spelling mistake, no functional change.

## Affected parts
- [ ] Library
- [ ] Test Application
- [ ] Perf Application
- [X] Other: build batch file

## Motivation and Context

## How Has This Been Tested?
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
