### PR TITLE
test: remove redundant initialization of variable j

### DIFF
--- a/test/zuc_test.c
+++ b/test/zuc_test.c
@@ -102,7 +102,7 @@ static uint32_t createData(uint8_t *pSrcData[MAXBUFS],
                 pSrcData[i] = (uint8_t *)malloc(MAX_BUFFER_LENGTH_IN_BYTES);
 
                 if (!pSrcData[i]) {
-                        uint32_t j = 0;
+                        uint32_t j;
 
                         printf("malloc(pSrcData[i]): failed!\n");
 
@@ -136,7 +136,7 @@ static uint32_t createKeyVecData(uint32_t keyLen, uint8_t *pKeys[MAXBUFS],
         uint32_t i = 0;
 
         for (i = 0; i < numOfBuffs; i++) {
-                uint32_t j = 0;
+                uint32_t j;
 
                 pIV[i] = (uint8_t *)malloc(ivLen);
 


### PR DESCRIPTION
Variable j is being initialized with zero however this value is never read and j is being re-assigned later in for-loop. Remove the redundant initialization.

Found using cppcheck static analysis

Signed-off-by: Colin Ian King <colin.i.king@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Minor static analysis clean up, remove redundant initializations of loop variable.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Library
- [x] Test Application
- [ ] Perf Application
- [ ] Other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Minor code clean up.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Build check only.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
