### PR TITLE
Enforce slash for folder path when running nasm with CMake

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -180,5 +180,4 @@ endforeach()
 
 # add include directories
 target_include_directories(${LIB} PRIVATE
-  ${DIR_CURRENT} ${DIR_INCLUDE} ${DIR_NO_AESNI})
-
+  ${DIR_CURRENT}// ${DIR_INCLUDE}// ${DIR_NO_AESNI}//)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 # set library directories
 #######################################
 set(DIR_CURRENT ${CMAKE_CURRENT_SOURCE_DIR}/)
-set(DIR_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set(DIR_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 set(DIR_AVX_T1 ${CMAKE_CURRENT_SOURCE_DIR}/avx_t1)
 set(DIR_AVX_T2 ${CMAKE_CURRENT_SOURCE_DIR}/avx_t2)
 set(DIR_AVX2_T1 ${CMAKE_CURRENT_SOURCE_DIR}/avx2_t1)
@@ -47,7 +47,7 @@ set(DIR_SSE_T1 ${CMAKE_CURRENT_SOURCE_DIR}/sse_t1)
 set(DIR_SSE_T2 ${CMAKE_CURRENT_SOURCE_DIR}/sse_t2)
 set(DIR_SSE_T3 ${CMAKE_CURRENT_SOURCE_DIR}/sse_t3)
 set(DIR_X86_64 ${CMAKE_CURRENT_SOURCE_DIR}/x86_64)
-set(DIR_NO_AESNI ${CMAKE_CURRENT_SOURCE_DIR}/no-aesni)
+set(DIR_NO_AESNI ${CMAKE_CURRENT_SOURCE_DIR}/no-aesni/)
 if(AVX_IFMA)
   set(DIR_AVX2_T3 ${CMAKE_CURRENT_SOURCE_DIR}/avx2_t3)
 endif()
@@ -180,4 +180,4 @@ endforeach()
 
 # add include directories
 target_include_directories(${LIB} PRIVATE
-  ${DIR_CURRENT}// ${DIR_INCLUDE}// ${DIR_NO_AESNI}//)
+  "${DIR_CURRENT}//" "${DIR_INCLUDE}//" "${DIR_NO_AESNI}//")


### PR DESCRIPTION
This PR fixes #131. Please, read #131 to obtain more information about.

## Description

Preserve slash character when including folders with nasm and CMake

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Library
- [ ] Test Application
- [ ] Perf Application
- [ ] Other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#131

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I built my changer locally:

```
$ cmake --build build/ --target IPSec_MB
/usr/bin/cmake -S/tmp/foobar/intel-ipsec-mb-1.4 -B/tmp/foobar/intel-ipsec-mb-1.4/build --check-build-system CMakeFiles/Makefile.cmake 0
/usr/bin/make  -f CMakeFiles/Makefile2 IPSec_MB
make[1]: Entering directory '/tmp/foobar/intel-ipsec-mb-1.4/build'
/usr/bin/cmake -S/tmp/foobar/intel-ipsec-mb-1.4 -B/tmp/foobar/intel-ipsec-mb-1.4/build --check-build-system CMakeFiles/Makefile.cmake 0
/usr/bin/cmake -E cmake_progress_start /tmp/foobar/intel-ipsec-mb-1.4/build/CMakeFiles 83
/usr/bin/make  -f CMakeFiles/Makefile2 lib/CMakeFiles/IPSec_MB.dir/all
make[2]: Entering directory '/tmp/foobar/intel-ipsec-mb-1.4/build'
/usr/bin/make  -f lib/CMakeFiles/IPSec_MB.dir/build.make lib/CMakeFiles/IPSec_MB.dir/depend
make[3]: Entering directory '/tmp/foobar/intel-ipsec-mb-1.4/build'
cd /tmp/foobar/intel-ipsec-mb-1.4/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /tmp/foobar/intel-ipsec-mb-1.4 /tmp/foobar/intel-ipsec-mb-1.4/lib /tmp/foobar/intel-ipsec-mb-1.4/build /tmp/foobar/intel-ipsec-mb-1.4/build/lib /tmp/foobar/intel-ipsec-mb-1.4/build/lib/CMakeFiles/IPSec_MB.dir/DependInfo.cmake --color=
make[3]: Leaving directory '/tmp/foobar/intel-ipsec-mb-1.4/build'
/usr/bin/make  -f lib/CMakeFiles/IPSec_MB.dir/build.make lib/CMakeFiles/IPSec_MB.dir/build
make[3]: Entering directory '/tmp/foobar/intel-ipsec-mb-1.4/build'
[  0%] Building ASM_NASM object lib/CMakeFiles/IPSec_MB.dir/avx2_t1/aes128_gcm_by8_avx2.asm.o
cd /tmp/foobar/intel-ipsec-mb-1.4/build/lib && /usr/bin/nasm -I/tmp/foobar/intel-ipsec-mb-1.4/lib/ -I/tmp/foobar/intel-ipsec-mb-1.4/lib/include/ -I/tmp/foobar/intel-ipsec-mb-1.4/lib/no-aesni/ -DSAFE_DATA -DSAFE_PARAM -DSAFE_LOOKUP -Werror -felf64 -Xgnu -gdwarf -DLINUX -D__linux__ -f elf64 -o CMakeFiles/IPSec_MB.dir/avx2_t1/aes128_gcm_by8_avx2.asm.o /tmp/foobar/intel-ipsec-mb-1.4/lib/avx2_t1/aes128_gcm_by8_avx2.asm
```

The important thing here is the include folders now with slash:

    /usr/bin/nasm -I/tmp/foobar/intel-ipsec-mb-1.4/lib/ -I/tmp/foobar/intel-ipsec-mb-1.4/lib/include/ -I/tmp/foobar/intel-ipsec-mb-1.4/lib/no-aesni/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
