### PR TITLE
CMake: Requires nasm 2.14 at least

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -158,6 +158,24 @@ enable_language(ASM_NASM)
 if(NOT CMAKE_ASM_NASM_COMPILER_LOADED)
   message(FATAL_ERROR "Can't find assembler")
 endif()
+
+set(NASM_MAJOR_REQUIRED 2)
+set(NASM_MINOR_REQUIRED 14)
+
+execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -v
+  OUTPUT_VARIABLE NASM_VERSION_OUTPUT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+string(REGEX MATCH "NASM version ([0-9]*).([0-9]*)" NASM_VERSION "${NASM_VERSION_OUTPUT}")
+if (NASM_VERSION)
+  if (NASM_MAJOR_REQUIRED GREATER ${CMAKE_MATCH_1} OR NASM_MINOR_REQUIRED GREATER ${CMAKE_MATCH_2})
+    message(FATAL_ERROR "NASM version must be at least ${NASM_MAJOR_REQUIRED}.${NASM_MINOR_REQUIRED}!")
+  endif()
+  message(STATUS "NASM version: ${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
+else()
+  message(WARNING "Could not parse NASM version string: ${NASM_VERSION_OUTPUT}.\nPlease, be sure that ${CMAKE_ASM_NASM_COMPILER} version is >= ${NASM_MAJOR_REQUIRED}.${NASM_MINOR_REQUIRED}.")
+endif()
+
 set(CAN_USE_ASSEMBLER 1)
 
 ########################################
@@ -181,4 +199,3 @@ endforeach()
 # add include directories
 target_include_directories(${LIB} PRIVATE
   ${DIR_CURRENT} ${DIR_INCLUDE} ${DIR_NO_AESNI})
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using `make` to build intel-ipsec-mb, the Makefile has a check for nasm minimal version. However, it does not happen when running CMake.

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Library
- [ ] Test Application
- [ ] Perf Application
- [x] Other: CMake configure step

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR replaces #132 by checking the nasm version to 2.14 or higher.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The CMake variable `CMAKE_ASM_NASM_COMPILER_VERSION` is not provided directly (see CMake source code: https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/CMakeASM_NASMInformation.cmake) so we need to parse `nasm` output and collect its version.

Once it's done, we just need to run cmake as usual:

```
$ cmake --build build/
-- Project Version: 1.4.0
-- AESNI emulation support... OFF
-- SAFE_OPTIONS...            ON
-- SAFE_PARAM...              ON
-- SAFE_DATA...               ON
-- SAFE_LOOKUP...             ON
-- BUILD_SHARED_LIBS...       ON
-- CMAKE_GENERATOR...         Unix Makefiles
-- BUILD_TYPE...              Release
-- CMAKE_VERBOSE_MAKEFILE...  OFF
-- OPERATING SYSTEM...        Linux
-- NASM version: 2.14
-- LIB_INSTALL_DIR...         /usr/local/lib
-- INCLUDE_INSTALL_DIR...     /usr/local/include
-- MAN_INSTALL_DIR...         /usr/local/man/man7
-- Configuring done
-- Generating done
-- Build files have been written to: /home/conan/project/build
[  0%] Building ASM_NASM object lib/CMakeFiles/IPSec_MB.dir/avx2_t1/aes192_gcm_by8_avx2.asm.o
```

The `NASM version: 2.14` shows that `nasm` is present and it's version is parsed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
