### PR TITLE
Remove printf that causes linker issue in environments like SGX

### DIFF
--- a/lib/include/snow3g_common.h
+++ b/lib/include/snow3g_common.h
@@ -35,7 +35,6 @@
 #ifndef SNOW3G_COMMON_H
 #define SNOW3G_COMMON_H
 
-#include <stdio.h>  /* printf() */
 #include <string.h> /* memset(), memcpy() */
 #include <stdint.h>
 
@@ -3103,7 +3102,6 @@ SNOW3G_F8_N_BUFFER(const snow3g_key_schedule_t *pCtx, const void *const IV[],
 
         if (packetCount > NUM_PACKETS_16) {
                 pBufferOut[0] = NULL;
-                printf("packetCount too high (%u)\n", (unsigned) packetCount);
                 return;
         }
 
@@ -3267,7 +3265,6 @@ SNOW3G_F8_N_BUFFER_MULTIKEY(const snow3g_key_schedule_t *const pCtx[], const voi
 
         if (packetCount > NUM_PACKETS_16) {
                 pBufferOut[0] = NULL;
-                printf("packetCount too high (%u)\n", (unsigned) packetCount);
                 return;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove printf that causes linker issue in environments like SGX

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Library
- [ ] Test Application
- [ ] Perf Application
- [ ] Other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In an embedded environment like SGX which does not have access to standard C libraries present in the system, the ipsec-mb library built with printf does not work and gives build errors. Fixes #142 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build in environment that links the static binary with SGX enclave

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
