### PR TITLE
lib: [cpuid] XSAVE and OSXSAVE required for all AVX architectures; fi…

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,12 @@
 ========================================================================
 Release Notes for Intel(R) Multi-Buffer Crypto for IPsec Library
 
+v1.2.1 September 2024
+========================================================================
+
+General
+- Add check for XSAVE and OSXSAVE CPU capabilities for all AVX architectures
+
 v1.2 February 2022
 ========================================================================
 

--- a/lib/intel-ipsec-mb.h
+++ b/lib/intel-ipsec-mb.h
@@ -91,8 +91,8 @@ typedef struct {
 /**
  * Library version
  */
-#define IMB_VERSION_STR "1.2.0"
-#define IMB_VERSION_NUM 0x10200
+#define IMB_VERSION_STR "1.2.1"
+#define IMB_VERSION_NUM 0x10201
 
 /**
  * Macro to translate version number
@@ -983,6 +983,8 @@ typedef uint32_t (*crc32_fn_t)(const void *, const uint64_t);
 #define IMB_FEATURE_AVX512_IFMA (1ULL << 17)
 #define IMB_FEATURE_BMI2       (1ULL << 18)
 #define IMB_FEATURE_AESNI_EMU  (1ULL << 19)
+#define IMB_FEATURE_XSAVE          (1ULL << 27)
+#define IMB_FEATURE_OSXSAVE        (1ULL << 28)
 
 /* TOP LEVEL (IMB_MGR) Data structure fields */
 

--- a/lib/x86_64/cpu_feature.c
+++ b/lib/x86_64/cpu_feature.c
@@ -180,6 +180,20 @@ static uint32_t detect_bmi2(void)
         return (cpuid_7_0.ebx & (1 << 8));
 }
 
+static uint32_t
+detect_xsave(void)
+{
+        /* Check presence of XSAVE - bit 26 of ECX */
+        return (cpuid_1_0.ecx & (1UL << 26));
+}
+
+static uint32_t
+detect_osxsave(void)
+{
+        /* Check presence of OSXSAVE - bit 27 of ECX */
+        return (cpuid_1_0.ecx & (1UL << 27));
+}
+
 uint64_t cpu_feature_detect(void)
 {
         static const struct {
@@ -204,6 +218,8 @@ uint64_t cpu_feature_detect(void)
                 { 7, IMB_FEATURE_GFNI, detect_gfni },
                 { 7, IMB_FEATURE_AVX512_IFMA, detect_avx512_ifma },
                 { 7, IMB_FEATURE_BMI2, detect_bmi2 },
+                { 1, IMB_FEATURE_XSAVE, detect_xsave },
+                { 1, IMB_FEATURE_OSXSAVE, detect_osxsave }
         };
         struct cpuid_regs r;
         unsigned hi_leaf_number = 0;

--- a/lib/x86_64/mb_mgr_auto.c
+++ b/lib/x86_64/mb_mgr_auto.c
@@ -49,7 +49,7 @@ init_mb_mgr_auto(IMB_MGR *state, IMB_ARCH *arch)
                 IMB_FEATURE_SSE4_2 | IMB_FEATURE_CMOV |
                 IMB_FEATURE_AESNI | IMB_FEATURE_PCLMULQDQ;
         const uint64_t detect_avx =
-                IMB_FEATURE_AVX | IMB_FEATURE_CMOV | IMB_FEATURE_AESNI;
+                IMB_FEATURE_AVX | IMB_FEATURE_CMOV | IMB_FEATURE_AESNI | IMB_FEATURE_XSAVE | IMB_FEATURE_OSXSAVE;
         const uint64_t detect_avx2 = IMB_FEATURE_AVX2 | detect_avx;
         const uint64_t detect_avx512 = IMB_FEATURE_AVX512_SKX | detect_avx2;
 

--- a/test/main.c
+++ b/test/main.c
@@ -281,6 +281,8 @@ print_hw_features(void)
                 { IMB_FEATURE_GFNI, "GFNI" },
                 { IMB_FEATURE_AVX512_IFMA, "AVX512-IFMA" },
                 { IMB_FEATURE_BMI2, "BMI2" },
+                { IMB_FEATURE_XSAVE, "XSAVE" },
+                { IMB_FEATURE_OSXSAVE, "OSXSAVE" },
         };
         IMB_MGR *p_mgr = NULL;
         unsigned i;

--- a/test/utils.c
+++ b/test/utils.c
@@ -209,7 +209,8 @@ detect_arch(uint8_t arch_support[IMB_ARCH_NUM])
         const uint64_t detect_sse =
                 IMB_FEATURE_SSE4_2 | IMB_FEATURE_CMOV | IMB_FEATURE_AESNI;
         const uint64_t detect_avx =
-                IMB_FEATURE_AVX | IMB_FEATURE_CMOV | IMB_FEATURE_AESNI;
+                IMB_FEATURE_AVX | IMB_FEATURE_CMOV | IMB_FEATURE_AESNI |
+                IMB_FEATURE_XSAVE | IMB_FEATURE_OSXSAVE;
         const uint64_t detect_avx2 = IMB_FEATURE_AVX2 | detect_avx;
         const uint64_t detect_avx512 = IMB_FEATURE_AVX512_SKX | detect_avx2;
         const uint64_t detect_noaesni = IMB_FEATURE_SSE4_2 | IMB_FEATURE_CMOV;


### PR DESCRIPTION
…xes #153

- require XSAVE & OSXSAVE for AVX architectures
  - AVX2 and AVX512 are super-sets of AVX features
- update test applications to display XSAVE and OSXSAVE CPU features
- bump version to v1.2.1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Affected parts
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Library
- [ ] Test Application
- [ ] Perf Application
- [ ] Other: (please specify)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
