### PR TITLE
Update linux.yml with `--output-on-failure` ctest option

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,7 +120,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -j 5 -C ${{env.BUILD_TYPE}}
+      run: ctest -j 5 -C ${{env.BUILD_TYPE}} --output-on-failure
 
     - name: Install
       working-directory: ${{github.workspace}}/build
@@ -153,5 +153,5 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -j 5 -C ${{env.BUILD_TYPE}}
+      run: ctest -j 5 -C ${{env.BUILD_TYPE}} --output-on-failure
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,7 +113,7 @@ jobs:
         repository: 'intel/intel-ipsec-mb'
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} && cat /proc/cpuinfo
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel

--- a/lib/sse_t1/sha1_one_block_sse.asm
+++ b/lib/sse_t1/sha1_one_block_sse.asm
@@ -551,6 +551,8 @@ sha1_update_sse:
 
 	mov 	r14, ARG3
 
+align 32
+process_block:
         ;; set up a-f based on h0-h4
 	mov	a, [SZ*0 + CTX]
 	mov	b, [SZ*1 + CTX]
@@ -558,8 +560,6 @@ sha1_update_sse:
 	mov	d, [SZ*3 + CTX]
 	mov	e, [SZ*4 + CTX]
 
-align 32
-process_block:
 	one_block
 
         ;; update result digest h0-h4

--- a/lib/sse_t1/sha1_one_block_sse.asm
+++ b/lib/sse_t1/sha1_one_block_sse.asm
@@ -562,17 +562,16 @@ align 32
 process_block:
 	one_block
 
-	add 	INP, 64
-	dec 	r14
-	cmp 	r14, 0
-	ja 	process_block
-
         ;; update result digest h0-h4
 	add	[SZ*0 + CTX], a
 	add	[SZ*1 + CTX], b
 	add	[SZ*2 + CTX], c
 	add	[SZ*3 + CTX], d
 	add	[SZ*4 + CTX], e
+
+	add 	INP, 64
+	dec 	r14
+	jnz 	process_block
 
 %ifndef LINUX
 	movdqa	xmm8, [rsp + 2 * 16]

--- a/lib/sse_t2/sha1_ni_one_block_sse.asm
+++ b/lib/sse_t2/sha1_ni_one_block_sse.asm
@@ -322,18 +322,17 @@ sha1_ni_update_sse:
 	movdqa		SHUF_MASK, [rel PSHUFFLE_BYTE_FLIP_MASK]
 	movdqa		E_MASK, [rel UPPER_WORD_MASK]
 
+align 32
+process_block:
 	;; Copy digests
 	movdqa		[rsp + frame.ABCD_SAVE], ABCD
 	movdqa		[rsp + frame.E_SAVE],    E0
 
-align 32
-process_block:
 	one_block_ni
 
 	add 		INP, 64
 	dec 		ARG3
-	cmp 		ARG3, 0
-	ja 		process_block
+	jnz 		process_block
 
 	;; write out digests
 	pshufd		ABCD, ABCD, 0x1B


### PR DESCRIPTION
This is to debug `ctest` failure on linux CI

## Checklist
- [ ] Updated relevant documentation (e.g., Release Notes, README files etc.)
- [ ] Added the relevant labels to PR (e.g. enhancement, bug fix, documentation, version etc.)
