### PR TITLE
test: [kat-app] remove unsafe SNOW3G key pointer casts

### DIFF
--- a/test/kat-app/snow3g_test.c
+++ b/test/kat-app/snow3g_test.c
@@ -168,7 +168,7 @@ snow3g_hexdump(const char *message, const uint8_t *ptr, int len)
 }
 
 static inline int
-submit_uea2_jobs(struct IMB_MGR *mb_mgr, uint8_t **const keys, uint8_t **const ivs,
+submit_uea2_jobs(struct IMB_MGR *mb_mgr, snow3g_key_schedule_t *const *keys, uint8_t **const ivs,
                  uint8_t **const src, uint8_t **const dst, const uint32_t *bitlens,
                  const uint32_t *bit_offsets, const int dir, const unsigned int num_jobs)
 {
@@ -379,8 +379,8 @@ validate_snow3g_f8_1_block(struct IMB_MGR *mb_mgr, uint32_t job_api,
                         uint32_t bit_len = length << 3;
                         uint32_t bit_offset = 0;
 
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, &pIV, &pSrcBuff,
-                                         &pSrcBuff, &bit_len, &bit_offset, IMB_DIR_ENCRYPT, 1);
+                        submit_uea2_jobs(mb_mgr, &pKeySched, &pIV, &pSrcBuff, &pSrcBuff, &bit_len,
+                                         &bit_offset, IMB_DIR_ENCRYPT, 1);
                 } else
                         IMB_SNOW3G_F8_1_BUFFER(mb_mgr, pKeySched, pIV, srcBuff, srcBuff, length);
 
@@ -400,8 +400,8 @@ validate_snow3g_f8_1_block(struct IMB_MGR *mb_mgr, uint32_t job_api,
                         unsigned bit_len = length << 3;
                         uint32_t bit_offset = 0;
 
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, &pIV, &pSrcBuff,
-                                         &pSrcBuff, &bit_len, &bit_offset, IMB_DIR_ENCRYPT, 1);
+                        submit_uea2_jobs(mb_mgr, &pKeySched, &pIV, &pSrcBuff, &pSrcBuff, &bit_len,
+                                         &bit_offset, IMB_DIR_ENCRYPT, 1);
                 } else
                         IMB_SNOW3G_F8_1_BUFFER(mb_mgr, pKeySched, pIV, srcBuff, srcBuff, length);
 
@@ -575,9 +575,9 @@ validate_snow3g_f8_1_bitblock(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                         /*Validate Encrypt*/
                         if (job_api)
-                                submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, &pIV,
-                                                 &srcBufAftPad, &midBufAftPad, &bit_len,
-                                                 &head_offset, IMB_DIR_ENCRYPT, 1);
+                                submit_uea2_jobs(mb_mgr, &pKeySched, &pIV, &srcBufAftPad,
+                                                 &midBufAftPad, &bit_len, &head_offset,
+                                                 IMB_DIR_ENCRYPT, 1);
                         else
                                 IMB_SNOW3G_F8_1_BUFFER_BIT(mb_mgr, pKeySched, pIV, srcBufAftPad,
                                                            midBufAftPad, bit_len, head_offset);
@@ -622,9 +622,9 @@ validate_snow3g_f8_1_bitblock(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                         /*Validate Decrypt*/
                         if (job_api)
-                                submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, &pIV,
-                                                 &dstBufAftPad, &midBufAftPad, &bit_len,
-                                                 &head_offset, IMB_DIR_DECRYPT, 1);
+                                submit_uea2_jobs(mb_mgr, &pKeySched, &pIV, &dstBufAftPad,
+                                                 &midBufAftPad, &bit_len, &head_offset,
+                                                 IMB_DIR_DECRYPT, 1);
                         else
                                 IMB_SNOW3G_F8_1_BUFFER_BIT(mb_mgr, pKeySched, pIV, dstBufAftPad,
                                                            midBufAftPad, bit_len, head_offset);
@@ -775,8 +775,8 @@ validate_snow3g_f8_2_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
                 /* TEST IN-PLACE ENCRYPTION/DECRYPTION */
                 /*Test the encrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pSrcBuff,
-                                         bitLens, bitOffsets, IMB_DIR_ENCRYPT, 2);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pSrcBuff, bitLens,
+                                         bitOffsets, IMB_DIR_ENCRYPT, 2);
                 else
                         IMB_SNOW3G_F8_2_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pSrcBuff[0],
                                                pSrcBuff[0], packetLen[0], pSrcBuff[1], pSrcBuff[1],
@@ -802,8 +802,8 @@ validate_snow3g_f8_2_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                 /*Test the decrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pSrcBuff,
-                                         bitLens, bitOffsets, IMB_DIR_DECRYPT, 2);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pSrcBuff, bitLens,
+                                         bitOffsets, IMB_DIR_DECRYPT, 2);
                 else
                         IMB_SNOW3G_F8_2_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pSrcBuff[0],
                                                pSrcBuff[0], packetLen[0], pSrcBuff[1], pSrcBuff[1],
@@ -825,8 +825,8 @@ validate_snow3g_f8_2_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
                 /* TEST OUT-OF-PLACE ENCRYPTION/DECRYPTION */
                 /*Test the encrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff,
-                                         bitLens, bitOffsets, IMB_DIR_ENCRYPT, 2);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
+                                         bitOffsets, IMB_DIR_ENCRYPT, 2);
                 else
                         IMB_SNOW3G_F8_2_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pSrcBuff[0],
                                                pDstBuff[0], packetLen[0], pSrcBuff[1], pDstBuff[1],
@@ -853,8 +853,8 @@ validate_snow3g_f8_2_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                 /*Test the decrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff,
-                                         bitLens, bitOffsets, IMB_DIR_DECRYPT, 2);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
+                                         bitOffsets, IMB_DIR_DECRYPT, 2);
                 else
                         IMB_SNOW3G_F8_2_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pSrcBuff[0],
                                                pDstBuff[0], packetLen[0], pSrcBuff[1], pDstBuff[1],
@@ -1015,8 +1015,8 @@ validate_snow3g_f8_4_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
                 /* TEST IN-PLACE ENCRYPTION/DECRYPTION */
                 /*Test the encrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pSrcBuff,
-                                         bitLens, bitOffsets, IMB_DIR_ENCRYPT, 4);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pSrcBuff, bitLens,
+                                         bitOffsets, IMB_DIR_ENCRYPT, 4);
                 else
                         IMB_SNOW3G_F8_4_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pIV[2], pIV[3],
                                                pSrcBuff[0], pSrcBuff[0], packetLen[0], pSrcBuff[1],
@@ -1044,8 +1044,8 @@ validate_snow3g_f8_4_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                 /*Test the decrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pSrcBuff,
-                                         bitLens, bitOffsets, IMB_DIR_DECRYPT, 4);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pSrcBuff, bitLens,
+                                         bitOffsets, IMB_DIR_DECRYPT, 4);
                 else
                         IMB_SNOW3G_F8_4_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pIV[2], pIV[3],
                                                pSrcBuff[0], pSrcBuff[0], packetLen[0], pSrcBuff[1],
@@ -1068,8 +1068,8 @@ validate_snow3g_f8_4_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
                 /* TEST OUT-OF-PLACE ENCRYPTION/DECRYPTION */
                 /*Test the encrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff,
-                                         bitLens, bitOffsets, IMB_DIR_ENCRYPT, 4);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
+                                         bitOffsets, IMB_DIR_ENCRYPT, 4);
                 else
                         IMB_SNOW3G_F8_4_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pIV[2], pIV[3],
                                                pSrcBuff[0], pDstBuff[0], packetLen[0], pSrcBuff[1],
@@ -1098,8 +1098,8 @@ validate_snow3g_f8_4_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
                 }
                 /*Test the decrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff,
-                                         bitLens, bitOffsets, IMB_DIR_DECRYPT, 4);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
+                                         bitOffsets, IMB_DIR_DECRYPT, 4);
                 else
                         IMB_SNOW3G_F8_4_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pIV[2], pIV[3],
                                                pSrcBuff[0], pDstBuff[0], packetLen[0], pSrcBuff[1],
@@ -1200,8 +1200,8 @@ validate_snow3g_f8_4_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
         /* Test the encrypt */
         if (job_api)
-                submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
-                                 bitOffsets, IMB_DIR_ENCRYPT, 4);
+                submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens, bitOffsets,
+                                 IMB_DIR_ENCRYPT, 4);
         else
                 IMB_SNOW3G_F8_4_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pIV[2], pIV[3],
                                        pSrcBuff[0], pDstBuff[0], packetLen[0], pSrcBuff[1],
@@ -1339,8 +1339,8 @@ validate_snow3g_f8_8_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                 /*Test the encrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff,
-                                         bitLens, bitOffsets, IMB_DIR_ENCRYPT, 8);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
+                                         bitOffsets, IMB_DIR_ENCRYPT, 8);
                 else
                         IMB_SNOW3G_F8_8_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pIV[2], pIV[3],
                                                pIV[4], pIV[5], pIV[6], pIV[7], pSrcBuff[0],
@@ -1366,8 +1366,8 @@ validate_snow3g_f8_8_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                 /*Test the decrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pDstBuff, pSrcBuff,
-                                         bitLens, bitOffsets, IMB_DIR_DECRYPT, 8);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pDstBuff, pSrcBuff, bitLens,
+                                         bitOffsets, IMB_DIR_DECRYPT, 8);
                 else
                         IMB_SNOW3G_F8_8_BUFFER(mb_mgr, pKeySched[0], pIV[0], pIV[1], pIV[2], pIV[3],
                                                pIV[4], pIV[5], pIV[6], pIV[7], pDstBuff[0],
@@ -1470,8 +1470,8 @@ validate_snow3g_f8_8_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
         /* Test the encrypt */
         if (job_api)
-                submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
-                                 bitOffsets, IMB_DIR_ENCRYPT, 8);
+                submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens, bitOffsets,
+                                 IMB_DIR_ENCRYPT, 8);
         else
                 IMB_SNOW3G_F8_8_BUFFER(
                         mb_mgr, pKeySched[0], pIV[0], pIV[1], pIV[2], pIV[3], pIV[4], pIV[5],
@@ -1615,8 +1615,8 @@ validate_snow3g_f8_8_blocks_multi_key(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
         /*Test the encrypt*/
         if (job_api)
-                submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
-                                 bitOffsets, IMB_DIR_ENCRYPT, 8);
+                submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens, bitOffsets,
+                                 IMB_DIR_ENCRYPT, 8);
         else
                 IMB_SNOW3G_F8_8_BUFFER_MULTIKEY(
                         mb_mgr, (const snow3g_key_schedule_t *const *) pKeySched,
@@ -1640,8 +1640,8 @@ validate_snow3g_f8_8_blocks_multi_key(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
         /*Test the decrypt*/
         if (job_api)
-                submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
-                                 bitOffsets, IMB_DIR_DECRYPT, 8);
+                submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens, bitOffsets,
+                                 IMB_DIR_DECRYPT, 8);
         else
                 IMB_SNOW3G_F8_8_BUFFER_MULTIKEY(
                         mb_mgr, (const snow3g_key_schedule_t *const *) pKeySched,
@@ -1784,8 +1784,8 @@ validate_snow3g_f8_n_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
         for (i = 0; i < IMB_SNOW3G_NUM_SUPPORTED_BUFFERS; i++) {
                 /*Test the encrypt*/
                 if (job_api) {
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff,
-                                         bitLens, bitOffsets, IMB_DIR_ENCRYPT, i + 1);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
+                                         bitOffsets, IMB_DIR_ENCRYPT, i + 1);
                 } else {
                         IMB_SNOW3G_F8_N_BUFFER(mb_mgr, *pKeySched, (const void *const *) pIV,
                                                (const void *const *) pSrcBuff, (void **) pDstBuff,
@@ -1807,8 +1807,8 @@ validate_snow3g_f8_n_blocks(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                 /*Test the Decrypt*/
                 if (job_api) {
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff,
-                                         bitLens, bitOffsets, IMB_DIR_DECRYPT, i + 1);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
+                                         bitOffsets, IMB_DIR_DECRYPT, i + 1);
                 } else {
                         IMB_SNOW3G_F8_N_BUFFER(mb_mgr, *pKeySched, (const void *const *) pIV,
                                                (const void *const *) pDstBuff, (void **) pSrcBuff,
@@ -1971,8 +1971,8 @@ validate_snow3g_f8_n_blocks_linear(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                 /*Test the encrypt*/
                 if (job_api) {
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff_const,
-                                         pDstBuff, bitLens, bitOffsets, IMB_DIR_ENCRYPT, i + 1);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff_const, pDstBuff, bitLens,
+                                         bitOffsets, IMB_DIR_ENCRYPT, i + 1);
                 } else {
                         IMB_SNOW3G_F8_N_BUFFER(mb_mgr, *pKeySched, (const void *const *) pIV,
                                                (const void *const *) pSrcBuff_const,
@@ -1995,8 +1995,8 @@ validate_snow3g_f8_n_blocks_linear(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                 /*Test the Decrypt*/
                 if (job_api) {
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pDstBuff_const,
-                                         pSrcBuff, bitLens, bitOffsets, IMB_DIR_DECRYPT, i + 1);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pDstBuff_const, pSrcBuff, bitLens,
+                                         bitOffsets, IMB_DIR_DECRYPT, i + 1);
                 } else {
                         IMB_SNOW3G_F8_N_BUFFER(mb_mgr, *pKeySched, (const void *const *) pIV,
                                                (const void *const *) pDstBuff_const,
@@ -2195,7 +2195,7 @@ validate_snow3g_f8_n_blocks_linear_mkeys(struct IMB_MGR *mb_mgr, uint32_t job_ap
                         }
 
                         if (job_api) {
-                                submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched[idx], &pIV[idx],
+                                submit_uea2_jobs(mb_mgr, &pKeySched[idx], &pIV[idx],
                                                  &pSrcBuff_const[idx], &pDstBuff[idx],
                                                  &bitLens[idx], &bitOffsets[idx], IMB_DIR_ENCRYPT,
                                                  nb_elem);
@@ -2239,7 +2239,7 @@ validate_snow3g_f8_n_blocks_linear_mkeys(struct IMB_MGR *mb_mgr, uint32_t job_ap
                         }
                         /*Test the Decrypt*/
                         if (job_api) {
-                                submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched[idx], &pIV[idx],
+                                submit_uea2_jobs(mb_mgr, &pKeySched[idx], &pIV[idx],
                                                  &pDstBuff_const[idx], &pSrcBuff[idx],
                                                  &bitLens[idx], &bitOffsets[idx], IMB_DIR_DECRYPT,
                                                  nb_elem);
@@ -2415,8 +2415,8 @@ validate_snow3g_f8_n_blocks_multi(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                 /*Test the encrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pSrcBuff, pDstBuff,
-                                         bitLens, bitOffsets, IMB_DIR_ENCRYPT, i + 1);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pSrcBuff, pDstBuff, bitLens,
+                                         bitOffsets, IMB_DIR_ENCRYPT, i + 1);
                 else
                         IMB_SNOW3G_F8_N_BUFFER_MULTIKEY(
                                 mb_mgr, (const snow3g_key_schedule_t *const *) pKeySched,
@@ -2441,8 +2441,8 @@ validate_snow3g_f8_n_blocks_multi(struct IMB_MGR *mb_mgr, uint32_t job_api,
 
                 /*Test the Decrypt*/
                 if (job_api)
-                        submit_uea2_jobs(mb_mgr, (uint8_t **) &pKeySched, pIV, pDstBuff, pSrcBuff,
-                                         bitLens, bitOffsets, IMB_DIR_DECRYPT, i + 1);
+                        submit_uea2_jobs(mb_mgr, pKeySched, pIV, pDstBuff, pSrcBuff, bitLens,
+                                         bitOffsets, IMB_DIR_DECRYPT, i + 1);
                 else
                         IMB_SNOW3G_F8_N_BUFFER_MULTIKEY(
                                 mb_mgr, (const snow3g_key_schedule_t *const *) pKeySched,


### PR DESCRIPTION
Change `submit_uea2_jobs()` to take `snow3g_key_schedule_t *const *keys` instead of `uint8_t **const` keys and update the call sites to pass typed key-schedule pointers directly. This removes unsafe pointer casts in the SNOW3G KAT job API path and fixes invalid key handling that triggers `IMB_STATUS_INVALID_ARGS` with newer Clang compilers such as clang-21 and clang-22.

## Description
When built with clang version >= 20, the KAT tests fail for SNOW3G-UEA.

Clang-22: SNOW3G KAT output before the patch:
```shell
./build/test/kat-app/imb-kat --test-type snow3g

Detected library version: 3.0.0-dev
Tool version: 3.0.0-dev
Detected hardware features:
        XSAVE         : OK
        OSXSAVE       : OK
        SHANI         : OK
        AESNI         : OK
        PCLMULQDQ     : OK
        MOVBE         : OK
        CMOV          : OK
        SSE4.2        : OK
        AVX           : OK
        AVX2          : OK
        AVX512(SKX)   : n/a
        VAES          : OK
        VPCLMULQDQ    : OK
        GFNI          : OK
        AVX512-IFMA   : n/a
        AVX-IFMA      : n/a
        BMI2          : OK
        HYBRID-CORE   : OK
        SM3NI         : n/a
        SM4NI         : n/a
        SHA512NI      : n/a
        APX           : n/a
        AVX10-256     : n/a
        AVX10-512     : n/a
SELF-TEST: PASS
[INFO] [ARCH] using SSE interface [SSE-SHANI-GFNI]
199 error status:4, job 0IMB_SNOW3G_F8_8_BUFFER(Enc) vector:1 buffer:0
Actual::
0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 
0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 


Expected::
0x5D 0x5B 0xFE 0x75 0xEB 0x04 0xF6 0x8C 0xE0 0xA1 0x23 0x77 0xEA 0x00 0xB3 0x7D 
0x47 0xC6 0xA0 0xBA 0x06 0x30 0x91 0x55 0x08 0x6A 0x85 0x9C 0x43 0x41 0xB3 0x7C 


199 error status:4, job 0snow3g_f8_8_multi_buffer(Enc) vector:1 buffer:0
Actual::
0x91 0x09 0x68 0xF8 0x95 0x60 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 
0x47 0xC6 0xA0 0xBA 0x06 0x30 0x91 0x55 0x08 0x6A 0x85 0x9C 0x43 0x41 0xB3 0x7C 


Expected::
0x5D 0x5B 0xFE 0x75 0xEB 0x04 0xF6 0x8C 0xE0 0xA1 0x23 0x77 0xEA 0x00 0xB3 0x7D 
0x47 0xC6 0xA0 0xBA 0x06 0x30 0x91 0x55 0x08 0x6A 0x85 0x9C 0x43 0x41 0xB3 0x7C 


[INFO] [ALGO] SNOW3G-UEA2 FAIL
[INFO] [ALGO] SNOW3G-UIA2 PASS
SELF-TEST: PASS
[INFO] [ARCH] using AVX2 interface [AVX2]
199 error status:4, job 0IMB_SNOW3G_F8_8_BUFFER(Enc) vector:1 buffer:0
Actual::
0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 
0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 


Expected::
0x5D 0x5B 0xFE 0x75 0xEB 0x04 0xF6 0x8C 0xE0 0xA1 0x23 0x77 0xEA 0x00 0xB3 0x7D 
0x47 0xC6 0xA0 0xBA 0x06 0x30 0x91 0x55 0x08 0x6A 0x85 0x9C 0x43 0x41 0xB3 0x7C 


199 error status:4, job 0snow3g_f8_8_multi_buffer(Enc) vector:1 buffer:0
Actual::
0xB1 0x01 0x68 0xF8 0x95 0x60 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 
0x47 0xC6 0xA0 0xBA 0x06 0x30 0x91 0x55 0x08 0x6A 0x85 0x9C 0x43 0x41 0xB3 0x7C 


Expected::
0x5D 0x5B 0xFE 0x75 0xEB 0x04 0xF6 0x8C 0xE0 0xA1 0x23 0x77 0xEA 0x00 0xB3 0x7D 
0x47 0xC6 0xA0 0xBA 0x06 0x30 0x91 0x55 0x08 0x6A 0x85 0x9C 0x43 0x41 0xB3 0x7C 


[INFO] [ALGO] SNOW3G-UEA2 FAIL
[INFO] [ALGO] SNOW3G-UIA2 PASS
Test completed: FAIL
``` 

As indicated by the error message specifically: `199 error status:4`
the problem occurs at the stage of passing data through the Job API. Status 4 is a `job->status` value equal to `IMB_STATUS_INVALID_ARGS`.

After a brief analysis, it became clear that the root cause of the error is an attempt to pass an invalid pointer to the keys for SNOW3G algorithms. In the `is_job_invalid()` function from `lib/include/mb_mgr_job_check.h` file, the keys are checked against `NULL` and fail this validation:

```c
                if (job->enc_keys == NULL) {
                        imb_set_errno(state, IMB_ERR_JOB_NULL_KEY);
                        return 1;
                }
``` 

This issue is unrelated to the algorithm implementations themselves, since execution never reaches them. The algorithms have also been tested via the Direct API. The problem is not an internal issue of the Job API either, as all keys are properly initialized in the test source code before the algorithms are executed.
This error occurs only in the Release build and is not detected in the Debug build.
It turns out that the root cause lies in the test code. Specifically, the issue is caused by passing keys between functions using a cast to `uint8_t **`.

## How Has This Been Tested?
Hardware:
```shell
Architecture:                x86_64
  CPU op-mode(s):            32-bit, 64-bit
  Address sizes:             46 bits physical, 48 bits virtual
  Byte Order:                Little Endian
CPU(s):                      12
  On-line CPU(s) list:       0-11
Vendor ID:                   GenuineIntel
  Model name:                13th Gen Intel(R) Core(TM) i7-1365U
    CPU family:              6
    Model:                   186
    Thread(s) per core:      2
    Core(s) per socket:      10
    Socket(s):               1
    Stepping:                3
    CPU max MHz:             5200.0000
    CPU min MHz:             400.0000
    BogoMIPS:                5376.00
    Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_kno
                             wn_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb ssbd ibrs ibpb stibp ibrs_enhanc
                             ed tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb intel_pt sha_ni xsaveopt xsavec xgetbv1 xsaves split_lock_detect user_shstk avx_vnni dtherm ida arat pln pts hwp hwp_not
                             ify hwp_act_window hwp_epp hwp_pkg_req hfi vnmi umip pku ospke waitpkg gfni vaes vpclmulqdq tme rdpid movdiri movdir64b fsrm md_clear serialize pconfig arch_lbr ibt flush_l1d arch_capabilities ibpb_exit_to_user
``` 

Compiler:
```shell
Ubuntu clang version 22.0.0 (++20251015042503+856555bfd843-1~exp1~20251015042630.2731)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-22/bin
``` 
Test command line:
`./build/test/kat-app/imb-kat --test-type snow3g`

Test output:
```shell
Detected library version: 3.0.0-dev
Tool version: 3.0.0-dev
Detected hardware features:
        XSAVE         : OK
        OSXSAVE       : OK
        SHANI         : OK
        AESNI         : OK
        PCLMULQDQ     : OK
        MOVBE         : OK
        CMOV          : OK
        SSE4.2        : OK
        AVX           : OK
        AVX2          : OK
        AVX512(SKX)   : n/a
        VAES          : OK
        VPCLMULQDQ    : OK
        GFNI          : OK
        AVX512-IFMA   : n/a
        AVX-IFMA      : n/a
        BMI2          : OK
        HYBRID-CORE   : OK
        SM3NI         : n/a
        SM4NI         : n/a
        SHA512NI      : n/a
        APX           : n/a
        AVX10-256     : n/a
        AVX10-512     : n/a
SELF-TEST: PASS
[INFO] [ARCH] using SSE interface [SSE-SHANI-GFNI]
[INFO] [ALGO] SNOW3G-UEA2 PASS
[INFO] [ALGO] SNOW3G-UIA2 PASS
SELF-TEST: PASS
[INFO] [ARCH] using AVX2 interface [AVX2]
[INFO] [ALGO] SNOW3G-UEA2 PASS
[INFO] [ALGO] SNOW3G-UIA2 PASS
Test completed: PASS
``` 

## Checklist
<!--- All checkboxes should be checked -->
- [x] Fixed for clang-21 build
- [x] Fixed for clang-22 build
