### PR TITLE
test: handle NULL start_ptr in hexdump_ex function

### DIFF
--- a/test/common/utils.c
+++ b/test/common/utils.c
@@ -119,7 +119,11 @@ hexdump_ex(FILE *fp, const char *msg, const void *p, size_t len, const void *sta
         while (ofs < len) {
                 unsigned int i;
 
-                fprintf(fp, "%p:", &start[ofs]);
+                if (start != NULL) {
+                        fprintf(fp, "%p:", &start[ofs]);
+                } else {
+                        fprintf(fp, "%08zx:", ofs);
+                }
 
                 for (i = 0; ((ofs + i) < len) && (i < 16); i++)
                         fprintf(fp, " %02x", (data[ofs + i] & 0xff));


### PR DESCRIPTION
In test/common/utils.c file hexdump_ex() documents that a NULL start_ptr should print indexes in the first column, but it still performed &start[ofs] unconditionally. Handle the NULL case explicitly by printing the current offset instead of doing pointer arithmetic on a NULL base. This keeps the existing address output for non-NULL start_ptr unchanged.

## Description
`hexdump_ex()` documents that a `NULL` `start_ptr` should display indexes in the first column of the output. However, the implementation always evaluated `&start[ofs]`, even when `start_ptr` was `NULL`, resulting in undefined behavior due to pointer arithmetic on a null pointer.

```c
void
hexdump_ex(FILE *fp, const char *msg, const void *p, size_t len, const void *start_ptr)
{
        // ...
        const char *start = (const char *) start_ptr;
        // ...
        while (ofs < len) {
                // ...
                fprintf(fp, "%p:", &start[ofs]);
                // ...
        }
        // ...
}
``` 

This path is reachable because `hexdump()` always calls `hexdump_ex()` with `start_ptr == NULL`:

```c
void
hexdump(FILE *fp, const char *msg, const void *p, size_t len)
{
        hexdump_ex(fp, msg, p, len, NULL);
} 
``` 
Handle the `NULL` case explicitly by printing the current offset instead of an address. Preserve the existing output format for non-`NULL` `start_ptr`.

## How Has This Been Tested?
The `hexdump()` function was temporarily invoked from the SHA KAT using:
```shell
./build/test/kat-app/imb-kat --test-type sha
```
Output before the fix:
```shell
Received
(nil): a9 99 3e 36 47 06 81 6a ba 3e 25 71 78 50 c2 6c | ..>6G..j.>%qxP.l
0x10: 9c d0 d8 9d |  |  |  |  |  |  |  |  |  |  |  |  | ....
Expected
(nil): a9 99 3e 36 47 06 81 6a ba 3e 25 71 78 50 c2 6c | ..>6G..j.>%qxP.l
0x10: 9c d0 d8 9d |  |  |  |  |  |  |  |  |  |  |  |  | ....
```
Output after the fix:
```shell
Received
00000000: a9 99 3e 36 47 06 81 6a ba 3e 25 71 78 50 c2 6c | ..>6G..j.>%qxP.l
00000010: 9c d0 d8 9d |  |  |  |  |  |  |  |  |  |  |  |  | ....
Expected
00000000: a9 99 3e 36 47 06 81 6a ba 3e 25 71 78 50 c2 6c | ..>6G..j.>%qxP.l
00000010: 9c d0 d8 9d |  |  |  |  |  |  |  |  |  |  |  |  | ....
```

## Checklist
<!--- All checkboxes should be checked -->
- [x] Align function behavior with its documented interface.
- [x] Verify the output of the `start_ptr == NULL` path.
